### PR TITLE
rename `plot.xequal`

### DIFF
--- a/R/plot-qstate.R
+++ b/R/plot-qstate.R
@@ -154,20 +154,22 @@ setMethod("plot", signature(x = "qstate", y = "missing"),
             }
           }
           )
-#' plot.xequal
+
+#' equalise_xcoord
 #'
 #' equalsizes the x-coordinates of all qubits in the plot
 #'
 #' @param x qstate object
 #'
 #' @examples
-#' x <- plot.xequal(x)
+#' x <- qstate(2)
+#' x <- equalise_xcoord(x)
 #'
 #' @return
 #' An object of S4 class 'qstate'
 #'
 #' @export
-plot.xequal <- function(x) {
+equalise_xcoord <- function(x) {
   gatelist <- x@circuit$gatelist
   x@circuit$equaly_xcoor <- c(x@circuit$equaly_xcoor, length(gatelist) + 1)
   return(x)


### PR DESCRIPTION
sorry that it took me so long to review this.

Here is one change which needs to be included before this can
be merged in. 'plot.xequal' is considered to be a generic plot
function, just by the name starting with 'plot.'. But it actually
isn't. So I renamed it.